### PR TITLE
docs: correct "TypeScript Node.js Projects" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The stack used in this learning repo, it is a mixture of [Jamstack](https://jams
 
 This repo is part of the [Certified Web 3.0 and Metaverse Developer Training Program](https://www.panaverse.co/)
 
-Before start learning from this repo, [learn TypeScript](https://github.com/panacloud-modern-global-apps/learn-typescript) and by doing these [TypeScript Node.js Projects](https://github.com/panacloud-modern-global-apps/chakra-nextjs-projects)
+Before start learning from this repo, [learn TypeScript](https://github.com/panacloud-modern-global-apps/learn-typescript) and by doing these [TypeScript Node.js Projects](https://github.com/panacloud-modern-global-apps/typescript-node-projects)
 
 After completing this repo you should move to these specialized Web 3 learning repos:
 


### PR DESCRIPTION
Correct the same link in the nextjs12 folder's README.md file as well, please:
https://github.com/panacloud-modern-global-apps/nextjs/blob/3c0f0b4dc8c20b0421e10300079c512b65682ca3/nextjs12/README.md?plain=1#L13